### PR TITLE
style: correct some properties' name & simplify code related to UploadController

### DIFF
--- a/Soil/Controller/UploadPostController.swift
+++ b/Soil/Controller/UploadPostController.swift
@@ -311,10 +311,11 @@ extension UploadPostController: TagsDelegate {
   
   func tagsLastTagAction(_ tagsView: TagsView, tagButton: TagButton) {
     let alertController = UIAlertController(title: nil, message: "태그 추가", preferredStyle: .alert)
-    alertController.addTextField(configurationHandler: { (textField) in
+    alertController.addTextField { (textField) in
       textField.returnKeyType = .next
       textField.becomeFirstResponder()
-    })
+    }
+    
     let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
     cancelAction.setValue(UIColor.black, forKey: "titleTextColor")
     let addAction = UIAlertAction(title: "추가", style: .default) { (_) in
@@ -326,6 +327,7 @@ extension UploadPostController: TagsDelegate {
     addAction.setValue(UIColor.black, forKey: "titleTextColor")
     alertController.addAction(cancelAction)
     alertController.addAction(addAction)
+    
     self.present(alertController, animated: true, completion: nil)
   }
   

--- a/Soil/Controller/UploadPostController.swift
+++ b/Soil/Controller/UploadPostController.swift
@@ -33,7 +33,7 @@ class UploadPostController: UIViewController {
   }
   
   private lazy var doneButton = UIBarButtonItem().then {
-    $0.title = "Done"
+    $0.title = "Write"
     $0.setTitleTextAttributes(titleButtonAttributes, for: .normal)
     $0.target = self
     $0.action = #selector(didTapDone)
@@ -393,7 +393,7 @@ extension UploadPostController: UploadPostInputAccessoryViewDelegate {
     // vc.delegate = self 설정
   }
   
-  func selectDone() {
+  func selectClose() {
     view.endEditing(true)
   }
 }

--- a/Soil/Controller/UploadPostController.swift
+++ b/Soil/Controller/UploadPostController.swift
@@ -94,7 +94,6 @@ class UploadPostController: UIViewController {
     $0.clipsToBounds = true
     $0.contentMode = .scaleAspectFill
     $0.snp.makeConstraints { make in
-      make.width.equalTo(330)
       make.height.equalTo(0)
     }
   }
@@ -211,7 +210,7 @@ class UploadPostController: UIViewController {
     contentsView.addSubview(imageView)
     imageView.snp.makeConstraints { make in
       make.top.equalTo(textView.snp.bottom).offset(100)
-      make.centerX.equalToSuperview()
+      make.leading.trailing.equalToSuperview().inset(20)
       make.bottom.lessThanOrEqualToSuperview().offset(-70)
     }
   }
@@ -416,7 +415,7 @@ extension UploadPostController: UIImagePickerControllerDelegate, UINavigationCon
     
     imageView.image = newImage
     imageView.snp.updateConstraints { make in
-      make.height.equalTo(200)
+      make.height.equalTo(300)
     }
     picker.dismiss(animated: true) {
       self.inputAccessoryView?.isHidden = false

--- a/Soil/Controller/UploadPostController.swift
+++ b/Soil/Controller/UploadPostController.swift
@@ -21,8 +21,8 @@ class UploadPostController: UIViewController {
   }
   
   private let titleButtonAttributes: [NSAttributedString.Key: Any] = [
-    NSAttributedString.Key.font: UIFont.montserrat(size: 16, family: .medium),
-    NSAttributedString.Key.foregroundColor: UIColor.black
+    .font: UIFont.montserrat(size: 16, family: .medium),
+    .foregroundColor: UIColor.black
   ]
   
   private lazy var cancelButton = UIBarButtonItem().then {
@@ -46,14 +46,14 @@ class UploadPostController: UIViewController {
   private let titleTextField = UITextField().then {
     $0.placeholder = "제목"
     var attributes: [NSAttributedString.Key: Any] = [
-      NSAttributedString.Key.font: UIFont.notoSansKR(size: 25, family: .regular),
-      NSAttributedString.Key.foregroundColor: UIColor.systemGray3
+      .font: UIFont.notoSansKR(size: 25, family: .regular),
+      .foregroundColor: UIColor.systemGray3
     ]
     $0.attributedPlaceholder = NSAttributedString(
       string: "제목",
       attributes: attributes
     )
-    attributes[NSAttributedString.Key.foregroundColor] = UIColor.black
+    attributes[.foregroundColor] = UIColor.black
     $0.defaultTextAttributes = attributes
     
     let spacer = UIView()
@@ -239,8 +239,8 @@ class UploadPostController: UIViewController {
     textView.delegate = self
     let text = "나만의 소중한 일상을 기록해보세요"
     let attributes: [NSAttributedString.Key: Any] = [
-      NSAttributedString.Key.font: UIFont.notoSansKR(size: 15, family: .regular),
-      NSAttributedString.Key.foregroundColor: UIColor.lightGray
+      .font: UIFont.notoSansKR(size: 15, family: .regular),
+      .foregroundColor: UIColor.lightGray
     ]
     textView.attributedText = NSAttributedString(string: text, attributes: attributes)
   }
@@ -286,8 +286,8 @@ extension UploadPostController: UITextViewDelegate {
     if textView.textColor == UIColor.lightGray {
       textView.text = nil
       let attributes: [NSAttributedString.Key: Any] = [
-        NSAttributedString.Key.font: UIFont.notoSansKR(size: 15, family: .regular),
-        NSAttributedString.Key.foregroundColor: UIColor.black
+        .font: UIFont.notoSansKR(size: 15, family: .regular),
+        .foregroundColor: UIColor.black
       ]
       textView.typingAttributes = attributes
     }
@@ -297,8 +297,8 @@ extension UploadPostController: UITextViewDelegate {
     if textView.text.isEmpty {
       let text = "나만의 소중한 일상을 기록해보세요"
       let attributes: [NSAttributedString.Key: Any] = [
-        NSAttributedString.Key.font: UIFont.notoSansKR(size: 15, family: .regular),
-        NSAttributedString.Key.foregroundColor: UIColor.lightGray
+        .font: UIFont.notoSansKR(size: 15, family: .regular),
+        .foregroundColor: UIColor.lightGray
       ]
       textView.attributedText = NSAttributedString(string: text, attributes: attributes)
     }

--- a/Soil/View/UploadPostInputAccessoryView.swift
+++ b/Soil/View/UploadPostInputAccessoryView.swift
@@ -10,7 +10,7 @@ import UIKit
 protocol UploadPostInputAccessoryViewDelegate: AnyObject {
   func selectPhoto()
   func selectMusic()
-  func selectDone()
+  func selectClose()
 }
 
 class UploadPostInputAccessoryView: UIView {
@@ -37,7 +37,7 @@ class UploadPostInputAccessoryView: UIView {
     $0.addTarget(self, action: #selector(addMusicTapped), for: .touchUpInside)
   }
   
-  private let doneButton = UIButton(type: .system).then {
+  private let closeButton = UIButton(type: .system).then {
     let attrs: [NSAttributedString.Key: Any] = [
       NSAttributedString.Key.font: UIFont.montserrat(size: 16, family: .semiBold),
       NSAttributedString.Key.foregroundColor: UIColor.black
@@ -46,7 +46,7 @@ class UploadPostInputAccessoryView: UIView {
       NSAttributedString(string: "Close", attributes: attrs),
       for: .normal
     )
-    $0.addTarget(self, action: #selector(doneTapped), for: .touchUpInside)
+    $0.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
   }
   
   // MARK: - Lifecycle
@@ -76,8 +76,8 @@ class UploadPostInputAccessoryView: UIView {
       make.centerY.equalTo(addPhotoButton)
     }
     
-    addSubview(doneButton)
-    doneButton.snp.makeConstraints { make in
+    addSubview(closeButton)
+    closeButton.snp.makeConstraints { make in
       make.trailing.equalToSuperview().offset(-30)
       make.centerY.equalTo(addPhotoButton)
     }
@@ -102,7 +102,7 @@ class UploadPostInputAccessoryView: UIView {
     self.delegate?.selectMusic()
   }
   
-  @objc private func doneTapped() {
-    self.delegate?.selectDone()
+  @objc private func closeTapped() {
+    self.delegate?.selectClose()
   }
 }

--- a/Soil/View/UploadPostInputAccessoryView.swift
+++ b/Soil/View/UploadPostInputAccessoryView.swift
@@ -39,8 +39,8 @@ class UploadPostInputAccessoryView: UIView {
   
   private let closeButton = UIButton(type: .system).then {
     let attrs: [NSAttributedString.Key: Any] = [
-      NSAttributedString.Key.font: UIFont.montserrat(size: 16, family: .semiBold),
-      NSAttributedString.Key.foregroundColor: UIColor.black
+      .font: UIFont.montserrat(size: 16, family: .semiBold),
+      .foregroundColor: UIColor.black
     ]
     $0.setAttributedTitle(
       NSAttributedString(string: "Close", attributes: attrs),


### PR DESCRIPTION
## Linked Issue

close #13 

## 설명

UploadController에서 일부 프로퍼티 이름과 UI에서 표시되는 글자를 바꾸고, 코드를 간략화시켰습니다.

## 변경 사항

- UploadPostController.swift
- UploadPostInputAccessoryView.swift

## 참고 사항

<!-- 스크린샷 또는 전하고 싶은 말을 자유롭게 적어주세요. -->

---

## Pull Request의 유형은 무엇인가요?

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Docs
- [x] Other

## 체크리스트

- [x] Merge하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
