### PR TITLE
feat: 이메일 인증 기능 추가

### DIFF
--- a/Soil.xcodeproj/project.pbxproj
+++ b/Soil.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		FA43FC552751158000A020D6 /* 20425-emailtitle.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "20425-emailtitle.json"; sourceTree = "<group>"; };
 		FA43FC582751165700A020D6 /* 70170-success-check.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "70170-success-check.json"; sourceTree = "<group>"; };
 		FA635F212796EDEE002D63C6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		FA65791727EB5169006B5D6D /* Soil.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Soil.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -352,6 +353,7 @@
 		3C45E0C227313ADA002E3C8D /* Soil */ = {
 			isa = PBXGroup;
 			children = (
+				FA65791727EB5169006B5D6D /* Soil.entitlements */,
 				3C10AFC9273296FC00B1E973 /* Model */,
 				3C10AFCA2732971500B1E973 /* View */,
 				3C10AFCB2732971E00B1E973 /* ViewModel */,
@@ -887,6 +889,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Soil/Soil.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
@@ -922,6 +925,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Soil/Soil.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Soil/Controller/Auth/EmailConfirmController.swift
+++ b/Soil/Controller/Auth/EmailConfirmController.swift
@@ -7,11 +7,13 @@
 
 import UIKit
 import Lottie
+import Firebase
 
 class EmailConfirmController: UIViewController {
   // MARK: - Properties
   let animationView = AnimationView()
   @IBOutlet weak var emailLabel: UILabel!
+  @IBOutlet weak var confirmLabel: UILabel!
   
   // MARK: - LifeCycle
   override func viewDidLoad() {
@@ -37,4 +39,25 @@ class EmailConfirmController: UIViewController {
     animationView.animationSpeed = 0.4
     view.addSubview(animationView)
   }
+  
+  // 인증 이메일 전송
+  @IBAction func didTabSendEmail(_ sender: Any) {
+    let email = AuthUser.shared.email
+    let actionCodeSettings = ActionCodeSettings()
+    if let email = email {
+      actionCodeSettings.url = URL(string: "https://soil-6d0b8.firebaseapp.com/?email=\(email)")
+      actionCodeSettings.handleCodeInApp = true
+      guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return }
+      actionCodeSettings.setIOSBundleID(bundleIdentifier)
+      
+      Auth.auth().sendSignInLink(toEmail: email, actionCodeSettings: actionCodeSettings) { error in
+        if let error = error {
+          print("email not sent \(error.localizedDescription)")
+        } else {
+          self.confirmLabel.text = "이메일을 다시 전송했어요."
+        }
+      }
+    }
+  }
+  
 }

--- a/Soil/Soil.entitlements
+++ b/Soil/Soil.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:soil.page.link</string>
+	</array>
+</dict>
+</plist>

--- a/Soil/Supporting/AppController.swift
+++ b/Soil/Supporting/AppController.swift
@@ -54,14 +54,14 @@ final class AppController {
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(checkLogin),
-      name: .loginStateDidChange, // <- Firebase Auth 이벤트
+      name: .loginStateDidChange, // 서버 로그인 체크
       object: nil
     )
   }
   
   @objc private func checkLogin() {
     let isSignIn = UserDefaults.standard.bool(forKey: "isSignIn") == true
-    if isSignIn { // <- Firebase Auth
+    if isSignIn { 
       setHome()
     } else {
       routeToLogin()

--- a/Soil/Supporting/Info.plist
+++ b/Soil/Supporting/Info.plist
@@ -2,6 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>Open_app</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.chuncheonian.Soil</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/Soil/Supporting/SceneDelegate.swift
+++ b/Soil/Supporting/SceneDelegate.swift
@@ -21,6 +21,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     configureIQKeyboardManager()
   }
   
+  func scene(_ scene: UIScene, continue userActivity: NSUserActivity) { // 동적 링크 클릭 시
+    NotificationCenter.default.post(name: .emailAuthStateDidChange, object: nil)
+  }
+  
   func sceneDidDisconnect(_ scene: UIScene) {}
   
   func sceneDidBecomeActive(_ scene: UIScene) {}

--- a/Soil/Utils/Extensions/NotificationNameExtension.swift
+++ b/Soil/Utils/Extensions/NotificationNameExtension.swift
@@ -8,4 +8,5 @@ import Foundation
 
 extension Notification.Name {
   static let loginStateDidChange = NSNotification.Name("loginStateDidChange")
+  static let emailAuthStateDidChange = NSNotification.Name("emailAuthStateDidChange")
 }

--- a/Soil/View/Auth/Auth.storyboard
+++ b/Soil/View/Auth/Auth.storyboard
@@ -72,7 +72,7 @@
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="335" id="O3Y-KF-79V"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" keyboardType="emailAddress"/>
+                                        <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="crW-h6-05U">
                                         <rect key="frame" x="0.0" y="38.5" width="335" height="50"/>
@@ -151,9 +151,6 @@
                                         <integer key="value" value="15"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <segue destination="4Mv-PZ-scx" kind="show" id="pcL-j7-F9M"/>
-                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rxi-qd-fVL">
                                 <rect key="frame" x="153" y="815" width="108" height="30"/>
@@ -168,6 +165,9 @@
                                         </fragment>
                                     </attributedString>
                                 </state>
+                                <connections>
+                                    <action selector="didTabSendEmail:" destination="0FC-7i-MB5" eventType="touchUpInside" id="8S8-op-rry"/>
+                                </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이메일을 확인해주세요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nYA-OB-G4m">
                                 <rect key="frame" x="84.5" y="423" width="245.5" height="36.5"/>
@@ -195,6 +195,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="YhU-YP-bwT"/>
                     <connections>
+                        <outlet property="confirmLabel" destination="nYA-OB-G4m" id="UFM-WZ-8as"/>
                         <outlet property="emailLabel" destination="eoT-tH-VvA" id="V3V-kj-4bT"/>
                     </connections>
                 </viewController>
@@ -257,25 +258,25 @@
         <!--Password Input Controller-->
         <scene sceneID="OLY-Lk-koB">
             <objects>
-                <viewController id="4Mv-PZ-scx" customClass="PasswordInputController" customModule="Soil" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="passwordVC" id="4Mv-PZ-scx" customClass="PasswordInputController" customModule="Soil" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ka8-GK-5ov">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="비밀번호를 입력해주세요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eY3-hc-6Pa">
-                                <rect key="frame" x="24" y="20" width="268.5" height="36.5"/>
+                                <rect key="frame" x="24" y="64" width="268.5" height="36.5"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Bold" family="Noto Sans KR" pointSize="25"/>
                                 <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1번만 입력하니 정확히 입력해주세요!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lhi-5H-FIv">
-                                <rect key="frame" x="24" y="70.5" width="185.5" height="17.5"/>
+                                <rect key="frame" x="24" y="114.5" width="185.5" height="17.5"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Bold" family="Noto Sans KR" pointSize="12"/>
                                 <color key="textColor" name="AAAAAA"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ppb-pz-lgE">
-                                <rect key="frame" x="32" y="708" width="350" height="50"/>
+                                <rect key="frame" x="32" y="762" width="350" height="50"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="Wet-a3-jqS"/>
@@ -293,7 +294,7 @@
                                 </connections>
                             </button>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ee1-Go-QX0">
-                                <rect key="frame" x="32" y="211" width="350" height="54.5"/>
+                                <rect key="frame" x="32" y="255" width="350" height="54.5"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="비밀번호" textAlignment="natural" minimumFontSize="17" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="wSH-jD-Al5" customClass="CustomPasswordTextField" customModule="Soil" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="350" height="17"/>


### PR DESCRIPTION

## Linked Issue

close #47

## 설명

- firebase dynamic link를 사용하여 이메일을 입력하면 해당 이메일에 메일 인증 링크를 보내도록 구현하였습니다.


## 변경 사항
__Add__
- Soil/Soil.entitlements

__Modify__
- Soil.xcodeproj/project.pbxproj
- Soil/Controller/Auth/EmailConfirmController.swift
- Soil/Controller/Auth/EmailInputViewController.swift
- Soil/Supporting/AppController.swift
- Soil/Supporting/Info.plist
- Soil/Supporting/SceneDelegate.swift
- Soil/Utils/Extensions/NotificationNameExtension.swift
- Soil/View/Auth/Auth.storyboard

## 참고 사항

---

## Pull Request의 유형은 무엇인가요?

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Docs
- [ ] Other

## 체크리스트

- [x] Merge하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
