### PR TITLE
fix: 프로필 편집화면에서 프로필 사진 삭제 버그 수정

### DIFF
--- a/Soil/API/Model/UserRequest.swift
+++ b/Soil/API/Model/UserRequest.swift
@@ -15,6 +15,7 @@ struct UpdateUserRequest: Encodable {
   let name: String
   let bio: String
   let file: Data?
+  let isDelete: Bool  // 기존에 사진이 있으면서 삭제하는 경우 true
 }
 
 struct PostUserRequest: Encodable {

--- a/Soil/API/Router/UserRouter.swift
+++ b/Soil/API/Router/UserRouter.swift
@@ -66,6 +66,7 @@ extension UserRouter: APIConfiguration {
     case .updateUser(let request):
       multipartFormData.append(request.name.data(using: .utf8)!, withName: "name")
       multipartFormData.append(request.bio.data(using: .utf8)!, withName: "bio")
+      multipartFormData.append(request.isDelete.description.data(using: .utf8)!, withName: "isDelete")
       
       if let file = request.file {
         multipartFormData.append(file, withName: "file", fileName: "\(file).jpeg", mimeType: "image/jpeg")

--- a/Soil/Controller/Profile/EditProfileController.swift
+++ b/Soil/Controller/Profile/EditProfileController.swift
@@ -29,6 +29,8 @@ final class EditProfileController: UIViewController {
     }
   }
   
+  private var isDeletedProfileImage = false
+  
   private let barButtonAttrs: [NSAttributedString.Key: Any] = [
     .font: UIFont.montserrat(size: 16, family: .medium)
   ]
@@ -149,13 +151,23 @@ final class EditProfileController: UIViewController {
   
   @objc func didTapDone() {
     guard let name = nameTextField.text,
-          let bio = bioTextView.text
+          let bio = bioTextView.text,
+          let viewModel = viewModel
     else { return }
+    
+    var isDeleteParameter = false
+    
+    // 기존에 사진이 있으면서, 삭제하는 경우 `isDelete` 파라미터 true로
+    if viewModel.profileImageURL?.absoluteString != "empty",
+       self.isDeletedProfileImage == true {
+        isDeleteParameter = true
+    }
     
     let request = UpdateUserRequest(
       name: name,
       bio: bio,
-      file: selectedProfileImage?.jpegData(compressionQuality: 0.75)
+      file: selectedProfileImage?.jpegData(compressionQuality: 0.75),
+      isDelete: isDeleteParameter
     )
         
     UserService.updateUser(request: request) { response in
@@ -186,6 +198,7 @@ final class EditProfileController: UIViewController {
       style: .destructive
     ) { _ in
       self.selectedProfileImage = nil
+      self.isDeletedProfileImage = true
     }
     
     let cancelAction = UIAlertAction(title: "취소", style: .cancel)
@@ -327,6 +340,7 @@ extension EditProfileController: UIImagePickerControllerDelegate, UINavigationCo
   ) {
     guard let selectedImage = info[.editedImage] as? UIImage else { return }
     selectedProfileImage = selectedImage
+    self.isDeletedProfileImage = false
     self.dismiss(animated: true, completion: nil)
   }
 }


### PR DESCRIPTION
## Linked Issue

close #49

## 설명

UpdateUser API에 `isDelete` 파라미터를 추가하여, EditProfileController에서 프로필 사진 삭제 기능 버그를 수정하였습니다.

## 변경 사항

<!-- 변경된 파일명을 적어주세요. -->
- API/Model/UserRequest
- API/Router/UserRouter
- Controller/Profile/EditProfileController

## 참고 사항

<!-- 스크린샷 또는 전하고 싶은 말을 자유롭게 적어주세요. -->

---

## Pull Request의 유형은 무엇인가요?

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactoring
- [ ] Docs
- [ ] Other

## 체크리스트

- [x] Merge하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?