### PR TITLE
feat: 검색 목록을 people, tag로 구분하도록 UI 구현 

### DIFF
--- a/Soil.xcodeproj/project.pbxproj
+++ b/Soil.xcodeproj/project.pbxproj
@@ -106,8 +106,10 @@
 		FA43A16D282170EC00569D01 /* Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA43A16C282170EC00569D01 /* Search.swift */; };
 		FA43FC572751158000A020D6 /* 20425-emailtitle.json in Resources */ = {isa = PBXBuildFile; fileRef = FA43FC552751158000A020D6 /* 20425-emailtitle.json */; };
 		FA43FC592751165700A020D6 /* 70170-success-check.json in Resources */ = {isa = PBXBuildFile; fileRef = FA43FC582751165700A020D6 /* 70170-success-check.json */; };
+		FA556E4D2850745100934027 /* TagCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA556E4C2850745100934027 /* TagCellModel.swift */; };
+		FA5751572835316100C8581F /* TagCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5751562835316100C8581F /* TagCell.swift */; };
 		FA635F222796EDEE002D63C6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FA635F212796EDEE002D63C6 /* GoogleService-Info.plist */; };
-		FAF00A9B2806D36700E965B2 /* SearchRecentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF00A9A2806D36700E965B2 /* SearchRecentTableViewCell.swift */; };
+		FAF00A9B2806D36700E965B2 /* SearchRecentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF00A9A2806D36700E965B2 /* SearchRecentCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -202,9 +204,11 @@
 		FA43A16C282170EC00569D01 /* Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search.swift; sourceTree = "<group>"; };
 		FA43FC552751158000A020D6 /* 20425-emailtitle.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "20425-emailtitle.json"; sourceTree = "<group>"; };
 		FA43FC582751165700A020D6 /* 70170-success-check.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "70170-success-check.json"; sourceTree = "<group>"; };
+		FA556E4C2850745100934027 /* TagCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCellModel.swift; sourceTree = "<group>"; };
+		FA5751562835316100C8581F /* TagCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCell.swift; sourceTree = "<group>"; };
 		FA635F212796EDEE002D63C6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		FA65791727EB5169006B5D6D /* Soil.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Soil.entitlements; sourceTree = "<group>"; };
-		FAF00A9A2806D36700E965B2 /* SearchRecentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRecentTableViewCell.swift; sourceTree = "<group>"; };
+		FAF00A9A2806D36700E965B2 /* SearchRecentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRecentCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -255,6 +259,7 @@
 				D5EF98E627A0C442004E6E55 /* UserCellModel.swift */,
 				FA3AC8382781DA3F00B8BDFF /* AuthUser.swift */,
 				FA43A16C282170EC00569D01 /* Search.swift */,
+				FA556E4C2850745100934027 /* TagCellModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -267,7 +272,8 @@
 				3CC1B09B2742BB6600A715C0 /* HorizontalSeperator.swift */,
 				3CC1B0A027439C1D00A715C0 /* UploadPostInputAccessoryView.swift */,
 				D5EF98DA279F8F23004E6E55 /* UserCell.swift */,
-				FAF00A9A2806D36700E965B2 /* SearchRecentTableViewCell.swift */,
+				FAF00A9A2806D36700E965B2 /* SearchRecentCell.swift */,
+				FA5751562835316100C8581F /* TagCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -713,13 +719,14 @@
 				3CC1B0A127439C1D00A715C0 /* UploadPostInputAccessoryView.swift in Sources */,
 				D569A38E2796A27800B7BA4A /* BaseInterceptor.swift in Sources */,
 				FA12E8052744CFB000EB8834 /* PasswordInputController.swift in Sources */,
-				FAF00A9B2806D36700E965B2 /* SearchRecentTableViewCell.swift in Sources */,
+				FAF00A9B2806D36700E965B2 /* SearchRecentCell.swift in Sources */,
 				3CC1B09C2742BB6600A715C0 /* HorizontalSeperator.swift in Sources */,
 				D57BEC0B274CEB8E00E65966 /* UITextFieldExtension.swift in Sources */,
 				D54299D027BB97BE002BF0EC /* GeneralResponse.swift in Sources */,
 				3CEC29E927CB803400294531 /* PostRouter.swift in Sources */,
 				D5D1224A273D1E3D0022290E /* YearController.swift in Sources */,
 				D569A3902796A95300B7BA4A /* MyLogger.swift in Sources */,
+				FA5751572835316100C8581F /* TagCell.swift in Sources */,
 				FA12E8022744CFB000EB8834 /* ProfileInputController.swift in Sources */,
 				FA43A16D282170EC00569D01 /* Search.swift in Sources */,
 				D57E8EB62740182E0099AA63 /* UserStatController.swift in Sources */,
@@ -763,6 +770,7 @@
 				3CEC29E727CB71C000294531 /* PostUploadRequest.swift in Sources */,
 				FA12E8032744CFB000EB8834 /* NickNameInputController.swift in Sources */,
 				D5C0A917273A5032005F9E9B /* UserService.swift in Sources */,
+				FA556E4D2850745100934027 /* TagCellModel.swift in Sources */,
 				FA12E8002744CFB000EB8834 /* EmailInputViewController.swift in Sources */,
 				3C45E0C627313ADA002E3C8D /* SceneDelegate.swift in Sources */,
 				FA33A23F27C3BD5500E29DF5 /* AuthRequest.swift in Sources */,

--- a/Soil/Controller/Search/SearchController.swift
+++ b/Soil/Controller/Search/SearchController.swift
@@ -19,7 +19,7 @@ class SearchController: UIViewController {
   private let tableView = UITableView().then {
     $0.backgroundColor = .clear
     $0.rowHeight = 50
-    $0.register(SearchRecentTableViewCell.self, forCellReuseIdentifier: SearchRecentTableViewCell.identifier)
+    $0.register(SearchRecentCell.self, forCellReuseIdentifier: SearchRecentCell.identifier)
   }
   
   private lazy var dataSource = setupDataSource()
@@ -81,9 +81,9 @@ class SearchController: UIViewController {
        tableView: tableView,
        cellProvider: { tableView, indexPath, model -> UITableViewCell? in
          guard let cell = tableView.dequeueReusableCell(
-           withIdentifier: SearchRecentTableViewCell.identifier,
+           withIdentifier: SearchRecentCell.identifier,
            for: indexPath
-         ) as? SearchRecentTableViewCell else { return UITableViewCell() }
+         ) as? SearchRecentCell else { return UITableViewCell() }
          
          // x버튼 클릭 시 cell 삭제
          cell.xButton.addTarget(

--- a/Soil/Controller/Search/SearchResultsTableController.swift
+++ b/Soil/Controller/Search/SearchResultsTableController.swift
@@ -7,67 +7,189 @@
 
 import UIKit
 
-private let reuseIdentifier = "UserCell"
+private let userCellIdentifier = "UserCell"
+private let tagCellIdentifier = "TagCell"
 
 protocol SearchResultsTableControllerDelegate: AnyObject {
   func didTapUsercell(uid: String)
 }
 
-class SearchResultsTableController: UITableViewController {
-
+class SearchResultsTableController: UIViewController {
+  
   // MARK: - Value Types
   
-  typealias DataSource = UITableViewDiffableDataSource<Int, UserCellModel>
-  typealias Snapshot = NSDiffableDataSourceSnapshot<Int, UserCellModel>
-  
+  typealias UserDataSource = UITableViewDiffableDataSource<Int, UserCellModel>
+  typealias UserSnapshot = NSDiffableDataSourceSnapshot<Int, UserCellModel>
+  typealias TagDataSource = UITableViewDiffableDataSource<Int, TagCellModel>
+  typealias TagSnapshot = NSDiffableDataSourceSnapshot<Int, TagCellModel>
+
   // MARK: - Properties
   
+  private let userTableView = UITableView().then {
+    $0.rowHeight = 64
+    $0.backgroundColor = .clear
+  }
+  
+  private let tagTableView = UITableView().then {
+    $0.rowHeight = 64
+    $0.backgroundColor = .clear
+  }
+  
+  private let containerView = UIView().then {
+    $0.backgroundColor = .soilBackgroundColor
+  }
+  
+  private var searchUserView = UIView().then {
+    $0.backgroundColor = .clear
+  }
+  
+  private var searchTagView = UIView().then {
+    $0.backgroundColor = .clear
+  }
+  private var searchSegmentedControl = UISegmentedControl()
   weak var delegate: SearchResultsTableControllerDelegate?
-  private lazy var dataSource = setupDataSource()
+  
+  private lazy var userDataSource = setupUserDataSource()
   private var userList = [UserCellModel]()
+  private lazy var tagDataSource = setupTagDataSource()
+  private var tagList: [TagCellModel] =
+      [TagCellModel(tag: "#tag1", tagCount: "10만 게시물"), TagCellModel(tag: "#tag2", tagCount: "1만 게시물")]
   
   // MARK: - Lifecycle
   
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = .soilBackgroundColor
+    
+    setSegmentedControl()
+    setConstraint()
+    applyTagSnapshot()
   }
   
   // MARK: - Method
   
-  private func setupDataSource() -> DataSource {
-    tableView.register(UserCell.self, forCellReuseIdentifier: reuseIdentifier)
-    tableView.rowHeight = 64
-    
-    dataSource = DataSource(
-      tableView: tableView,
-      cellProvider: { tableView, indexPath, userCell in
-        guard let cell = tableView.dequeueReusableCell(
-          withIdentifier: reuseIdentifier,
-          for: indexPath
-        ) as? UserCell else { return UITableViewCell() }
-        
-        cell.viewModel = UserCellViewModel(userCell: userCell)
-        
-        return cell
-    })
-    return dataSource
+  private func setSegmentedControl() {
+    let items = ["People", "Tag"]
+    searchSegmentedControl = UISegmentedControl(items: items)
+    searchSegmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged), for: .valueChanged)
+    searchSegmentedControl.backgroundColor = .systemGray5
+    searchSegmentedControl.tintColor = .white
+    searchSegmentedControl.selectedSegmentIndex = 0
   }
   
-  private func applySnapshot() {
-    var snapshot = Snapshot()
+  private func setConstraint() {
+    view.addSubview(searchSegmentedControl)
+    searchSegmentedControl.snp.makeConstraints { make in
+      make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(5)
+      make.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(15)
+      make.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-15)
+      make.height.equalTo(30)
+    }
+    
+    view.addSubview(containerView)
+    containerView.snp.makeConstraints { make in
+      make.top.equalTo(searchSegmentedControl.snp.bottom).offset(10)
+      make.leading.equalTo(view.safeAreaLayoutGuide.snp.leading)
+      make.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing)
+      make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
+    }
+    
+    containerView.addSubview(searchTagView)
+    searchTagView.snp.makeConstraints { make in
+      make.top.equalTo(containerView.snp.top)
+      make.leading.equalTo(containerView.snp.leading)
+      make.trailing.equalTo(containerView.snp.trailing)
+      make.bottom.equalTo(containerView.snp.bottom)
+    }
+    
+    containerView.addSubview(searchUserView)
+    searchUserView.snp.makeConstraints { make in
+      make.top.equalTo(containerView.snp.top)
+      make.leading.equalTo(containerView.snp.leading)
+      make.trailing.equalTo(containerView.snp.trailing)
+      make.bottom.equalTo(containerView.snp.bottom)
+    }
+    
+    searchUserView.addSubview(userTableView)
+    userTableView.snp.makeConstraints { make in
+      make.top.equalTo(searchUserView.snp.top)
+      make.leading.equalTo(searchUserView.snp.leading)
+      make.trailing.equalTo(searchUserView.snp.trailing)
+      make.bottom.equalTo(searchUserView.snp.bottom)
+    }
+    
+    searchTagView.addSubview(tagTableView)
+    tagTableView.snp.makeConstraints { make in
+      make.top.equalTo(searchTagView.snp.top)
+      make.leading.equalTo(searchTagView.snp.leading)
+      make.trailing.equalTo(searchTagView.snp.trailing)
+      make.bottom.equalTo(searchTagView.snp.bottom)
+    }
+    
+    searchUserView.alpha = 1.0
+    searchTagView.alpha = 0.0
+  }
+  
+  @objc func segmentedControlValueChanged(_ sender: UISegmentedControl) {
+    switch sender.selectedSegmentIndex {
+    case 0 :
+      searchTagView.alpha = 0.0
+      searchUserView.alpha = 1.0
+    default:
+      searchUserView.alpha = 0.0
+      searchTagView.alpha = 1.0
+    }
+  }
+  
+  private func setupUserDataSource() -> UserDataSource {
+    userTableView.delegate = self
+    userTableView.register(UserCell.self, forCellReuseIdentifier: userCellIdentifier)
+    userDataSource = UserDataSource(
+      tableView: userTableView,
+      cellProvider: { tableView, indexPath, userCell in
+        guard let cell = tableView.dequeueReusableCell(
+          withIdentifier: userCellIdentifier,
+          for: indexPath
+        ) as? UserCell else { return UITableViewCell() }
+
+        cell.viewModel = UserCellViewModel(userCell: userCell)
+
+        return cell
+    })
+    return userDataSource
+  }
+  
+  private func setupTagDataSource() -> TagDataSource {
+    tagTableView.delegate = self
+    tagTableView.register(TagCell.self, forCellReuseIdentifier: tagCellIdentifier)
+    tagDataSource = TagDataSource(
+      tableView: tagTableView,
+      cellProvider: { tableView, indexPath, _ in
+        guard let cell = tableView.dequeueReusableCell(
+          withIdentifier: tagCellIdentifier,
+          for: indexPath
+        ) as? TagCell else { return UITableViewCell() }
+
+        cell.tagLabel.text = self.tagList[indexPath.row].tag
+        cell.tagCountLabel.text = self.tagList[indexPath.row].tagCount
+
+        return cell
+    })
+    return tagDataSource
+  }
+  
+  private func applyUserSnapshot() {
+    var snapshot = UserSnapshot()
     snapshot.appendSections([0])
     snapshot.appendItems(userList)
-    dataSource.apply(snapshot, animatingDifferences: false)
+    userDataSource.apply(snapshot, animatingDifferences: false)
   }
-}
-
-// MARK: - UITableView
-
-extension SearchResultsTableController {
-  override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    tableView.deselectRow(at: indexPath, animated: true)
-    self.delegate?.didTapUsercell(uid: userList[indexPath.row].uid)
+  
+  private func applyTagSnapshot() {
+    var snapshot = TagSnapshot()
+    snapshot.appendSections([0])
+    snapshot.appendItems(tagList)
+    tagDataSource.apply(snapshot, animatingDifferences: false)
   }
   
 }
@@ -77,15 +199,23 @@ extension SearchResultsTableController {
 extension SearchResultsTableController: UISearchResultsUpdating { 
   func updateSearchResults(for searchController: UISearchController) {
     guard let text = searchController.searchBar.text?.lowercased() else { return }
-    
     if !text.isEmpty {
-      let request = SearchRequest(query: text, type: "user")
-      
-      SearchService.search(request: request) { response in
-        guard let userList = response.value?.data else { return }
-        self.userList = userList
-        self.applySnapshot()
-      }
-    }
+       let request = SearchRequest(query: text, type: "user")
+       
+       SearchService.search(request: request) { response in
+         guard let userList = response.value?.data else { return }
+         self.userList = userList
+         self.applyUserSnapshot()
+       }
+     }
+  }
+}
+
+// MARK: - UITableView
+
+extension SearchResultsTableController: UITableViewDelegate {
+  func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+    tableView.deselectRow(at: indexPath, animated: true)
+    self.delegate?.didTapUsercell(uid: userList[indexPath.row].uid)
   }
 }

--- a/Soil/Controller/Search/SearchResultsTableController.swift
+++ b/Soil/Controller/Search/SearchResultsTableController.swift
@@ -7,9 +7,6 @@
 
 import UIKit
 
-private let userCellIdentifier = "UserCell"
-private let tagCellIdentifier = "TagCell"
-
 protocol SearchResultsTableControllerDelegate: AnyObject {
   func didTapUsercell(uid: String)
 }
@@ -48,6 +45,9 @@ class SearchResultsTableController: UIViewController {
   }
   private var searchSegmentedControl = UISegmentedControl()
   weak var delegate: SearchResultsTableControllerDelegate?
+  
+  private let userCellIdentifier = "UserCell"
+  private let tagCellIdentifier = "TagCell"
   
   private lazy var userDataSource = setupUserDataSource()
   private var userList = [UserCellModel]()
@@ -148,7 +148,7 @@ class SearchResultsTableController: UIViewController {
       tableView: userTableView,
       cellProvider: { tableView, indexPath, userCell in
         guard let cell = tableView.dequeueReusableCell(
-          withIdentifier: userCellIdentifier,
+          withIdentifier: self.userCellIdentifier,
           for: indexPath
         ) as? UserCell else { return UITableViewCell() }
 
@@ -166,7 +166,7 @@ class SearchResultsTableController: UIViewController {
       tableView: tagTableView,
       cellProvider: { tableView, indexPath, _ in
         guard let cell = tableView.dequeueReusableCell(
-          withIdentifier: tagCellIdentifier,
+          withIdentifier: self.tagCellIdentifier,
           for: indexPath
         ) as? TagCell else { return UITableViewCell() }
 

--- a/Soil/Model/TagCellModel.swift
+++ b/Soil/Model/TagCellModel.swift
@@ -1,0 +1,14 @@
+//
+//  TagCellModel.swift
+//  Soil
+//
+//  Created by 임영선 on 2022/06/08.
+//
+
+import Foundation
+
+struct TagCellModel: Codable, Hashable {
+  private(set) var uuid = UUID()
+  let tag: String
+  let tagCount: String
+}

--- a/Soil/View/SearchRecentCell.swift
+++ b/Soil/View/SearchRecentCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class SearchRecentTableViewCell: UITableViewCell {
+class SearchRecentCell: UITableViewCell {
   
   // MARK: - Properties
   

--- a/Soil/View/TagCell.swift
+++ b/Soil/View/TagCell.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import MapKit
 
 class TagCell: UITableViewCell {
   

--- a/Soil/View/TagCell.swift
+++ b/Soil/View/TagCell.swift
@@ -1,0 +1,78 @@
+//
+//  TagCell.swift
+//  Soil
+//
+//  Created by 임영선 on 2022/05/18.
+//
+
+import UIKit
+import MapKit
+
+class TagCell: UITableViewCell {
+  
+  // MARK: - Properties
+  
+  private let tagView = UIView().then {
+    $0.snp.makeConstraints { make in
+      make.width.height.equalTo(50)
+    }
+    $0.layer.cornerRadius = 50 / 2
+    $0.backgroundColor = .black
+  }
+  
+  private let tagViewLabel = UILabel().then {
+    $0.text = "#"
+    $0.font = UIFont.ceraPro(size: 35, family: .bold)
+    $0.textColor = .white
+  }
+  
+  let tagLabel = UILabel().then {
+    $0.font = UIFont.ceraPro(size: 16, family: .bold)
+    $0.textColor = .black
+  }
+  
+  let tagCountLabel = UILabel().then {
+    $0.font = UIFont.notoSansKR(size: 11, family: .regular)
+    $0.textColor = .systemGray
+  }
+
+  override func awakeFromNib() {
+    super.awakeFromNib()
+  }
+  
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+    selectionStyle = .none
+    backgroundColor = .soilBackgroundColor
+    configureUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func configureUI() {
+    addSubview(tagView)
+    tagView.snp.makeConstraints { make in
+      make.centerY.equalToSuperview()
+      make.leading.equalTo(self.safeAreaLayoutGuide.snp.leading).offset(21)
+    }
+    
+    tagView.addSubview(tagViewLabel)
+    tagViewLabel.snp.makeConstraints { make in
+      make.centerX.equalToSuperview()
+      make.centerY.equalToSuperview()
+    }
+    
+    let stack = UIStackView(arrangedSubviews: [tagLabel, tagCountLabel])
+    stack.axis = .vertical
+    stack.spacing = 2
+    stack.alignment = .leading
+    
+    addSubview(stack)
+    stack.snp.makeConstraints { make in
+      make.centerY.equalToSuperview().offset(5)
+      make.leading.equalTo(self.tagView.safeAreaLayoutGuide.snp.trailing).offset(12)
+    }
+  }
+}


### PR DESCRIPTION

## Linked Issue

close #60

## 설명

- `sgmented control`로 검색 목록을 people, tag로 구분할 수 있게 구현했습니다.

## 변경 사항
Rename
- Soil/View/SearchRecentTableViewCell.swift → Soil/View/SearchRecentCell.swift

Modify
- Soil.xcodeproj/project.pbxproj
- Soil/Controller/Search/SearchController.swift
- Soil/Controller/Search/SearchResultsTableController.swift

Add
- Soil/Model/TagCellModel.swift
- Soil/View/TagCell.swift

## 참고 사항
<img width="250" src="https://user-images.githubusercontent.com/77915491/172592568-fee028e3-eb85-40e7-b0f3-a81bae7b78f2.png">



---

## Pull Request의 유형은 무엇인가요?

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Docs
- [ ] Other

## 체크리스트

- [x] Merge하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
